### PR TITLE
Support keystore certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and minimize the interactions with the ConnId framework and have much of that
 taken care of by a common API.
 
 # Change Log
+
++ **4.2.14** - Added Keystore Certificate loading (03/11/2025).
 + **4.2.13** - Added Annotation-based adpator (03/10/2025).
 + **4.2.12** - FIN-12352 - Modify how schema meta info is created (01/15/2025)
 + **4.2.11** - FIN-12722 - Add CacheMap implementation and fullConnectionTest method to BaseConnector (01/10/2025)

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,9 @@ sourceCompatibility = '1.11'
 targetCompatibility = '1.11'
 group = 'com.exclamationlabs.connid'
 
+def rc_version = System.getenv('RELEASE_CANDIDATE') == null || System.getenv('RELEASE_CANDIDATE') == "" ? "" : "-rc.${System.getenv('RELEASE_CANDIDATE')}"
 def build_version = System.getenv('BUILD_NUMBER') == null ? System.currentTimeMillis() : System.getenv('BUILD_NUMBER')
-project.version="${software_version}-${build_version}"
+project.version="${software_version}${rc_version}+${build_version}"
 
 dependencyLocking {
     lockAllConfigurations()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-software_version=4.2.13
+software_version=4.2.14
 test_connector_version=3.0.4
 spring_boot_version=2.7.18
 

--- a/src/main/java/com/exclamationlabs/connid/base/connector/authenticator/client/HttpsKeystoreCertificateClientLoader.java
+++ b/src/main/java/com/exclamationlabs/connid/base/connector/authenticator/client/HttpsKeystoreCertificateClientLoader.java
@@ -44,7 +44,7 @@ public class HttpsKeystoreCertificateClientLoader
     TrustManager trustManager = setupTrustManager();
 
     try {
-      SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+      SSLContext sslContext = SSLContext.getInstance(configuration.getTlsVersion());
 
       KeyManagerFactory keyManagerFactory =
           KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());

--- a/src/main/java/com/exclamationlabs/connid/base/connector/authenticator/client/HttpsPfxCertificateClientLoader.java
+++ b/src/main/java/com/exclamationlabs/connid/base/connector/authenticator/client/HttpsPfxCertificateClientLoader.java
@@ -16,7 +16,7 @@
 
 package com.exclamationlabs.connid.base.connector.authenticator.client;
 
-import com.exclamationlabs.connid.base.connector.configuration.basetypes.security.KeyStoreConfiguration;
+import com.exclamationlabs.connid.base.connector.configuration.basetypes.security.PfxConfiguration;
 import com.exclamationlabs.connid.base.connector.util.GuardedStringUtil;
 import java.io.IOException;
 import java.security.*;
@@ -34,12 +34,11 @@ import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.identityconnectors.common.security.GuardedString;
 import org.identityconnectors.framework.common.exceptions.ConnectorSecurityException;
 
-/** Workhorse to create a secure HttpClient using a supplied KeyStore. */
-public class HttpsKeystoreCertificateClientLoader
-    implements SecureClientLoader<KeyStoreConfiguration> {
+/** Workhorse to create a secure HttpClient using a supplied PFX file. */
+public class HttpsPfxCertificateClientLoader implements SecureClientLoader<PfxConfiguration> {
 
   @Override
-  public HttpClient load(KeyStoreConfiguration configuration, KeyStore keyStore)
+  public HttpClient load(PfxConfiguration configuration, KeyStore keyStore)
       throws ConnectorSecurityException {
     TrustManager trustManager = setupTrustManager();
 
@@ -52,7 +51,7 @@ public class HttpsKeystoreCertificateClientLoader
       GuardedString keyPassword =
           configuration.getKeyPassword() != null
               ? configuration.getKeyPassword()
-              : configuration.getKeystorePassword();
+              : configuration.getPfxPassword();
 
       // Use original keystore if no alias specified
       KeyStore storeToUse = keyStore;

--- a/src/main/java/com/exclamationlabs/connid/base/connector/authenticator/client/HttpsPfxCertificateClientLoader.java
+++ b/src/main/java/com/exclamationlabs/connid/base/connector/authenticator/client/HttpsPfxCertificateClientLoader.java
@@ -112,12 +112,12 @@ public class HttpsPfxCertificateClientLoader implements SecureClientLoader<PfxCo
 
       @Override
       public void checkClientTrusted(X509Certificate[] chain, String authType) {
-        checkCertificateChain(chain, authType);
+        checkCertificateChain(chain);
       }
 
       @Override
       public void checkServerTrusted(X509Certificate[] chain, String authType) {
-        checkCertificateChain(chain, authType);
+        checkCertificateChain(chain);
       }
 
       @Override
@@ -125,8 +125,7 @@ public class HttpsPfxCertificateClientLoader implements SecureClientLoader<PfxCo
         return acceptedChain;
       }
 
-      private void checkCertificateChain(
-          java.security.cert.X509Certificate[] chain, String authType) {
+      private void checkCertificateChain(java.security.cert.X509Certificate[] chain) {
         try {
           if (chain == null || chain.length == 0) {
             throw new IllegalArgumentException("Received empty/null certificate chain");

--- a/src/main/java/com/exclamationlabs/connid/base/connector/authenticator/client/HttpsPfxCertificateClientLoader.java
+++ b/src/main/java/com/exclamationlabs/connid/base/connector/authenticator/client/HttpsPfxCertificateClientLoader.java
@@ -43,7 +43,7 @@ public class HttpsPfxCertificateClientLoader implements SecureClientLoader<PfxCo
     TrustManager trustManager = setupTrustManager();
 
     try {
-      SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
+      SSLContext sslContext = SSLContext.getInstance(configuration.getTlsVersion());
 
       KeyManagerFactory keyManagerFactory =
           KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());

--- a/src/main/java/com/exclamationlabs/connid/base/connector/authenticator/keys/JceksKeyStoreLoader.java
+++ b/src/main/java/com/exclamationlabs/connid/base/connector/authenticator/keys/JceksKeyStoreLoader.java
@@ -1,0 +1,62 @@
+/*
+    Copyright 2020 Exclamation Labs
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+package com.exclamationlabs.connid.base.connector.authenticator.keys;
+
+import com.exclamationlabs.connid.base.connector.authenticator.util.FileLoaderUtil;
+import com.exclamationlabs.connid.base.connector.configuration.basetypes.security.KeyStoreConfiguration;
+import com.exclamationlabs.connid.base.connector.util.GuardedStringUtil;
+import java.io.*;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import org.apache.commons.lang3.StringUtils;
+import org.identityconnectors.framework.common.exceptions.ConnectorSecurityException;
+
+/** Implementation to load a KeyStore from a Keystore file. */
+public class JceksKeyStoreLoader<T> implements KeyStoreLoader<KeyStoreConfiguration> {
+
+  @Override
+  public KeyStore load(KeyStoreConfiguration configuration) throws ConnectorSecurityException {
+    final String KEYSTORE_PASSWORD = GuardedStringUtil.read(configuration.getKeystorePassword());
+    final String KEYSTORE_PATH =
+        FileLoaderUtil.getFileLocation(
+            configuration.getName(), "pfxFile", configuration.getKeystoreFile());
+    InputStream pfxInputStream;
+    try {
+      if (StringUtils.startsWith(KEYSTORE_PATH, "resource:")) {
+        final String RESOURCE_NAME = StringUtils.substringAfter(KEYSTORE_PATH, "resource:");
+        pfxInputStream = getClass().getClassLoader().getResourceAsStream(RESOURCE_NAME);
+        if (pfxInputStream == null) {
+          throw new ConnectorSecurityException("JCEKS File resource not found: " + RESOURCE_NAME);
+        }
+      } else {
+        pfxInputStream = new FileInputStream(KEYSTORE_PATH);
+      }
+      KeyStore keystore = KeyStore.getInstance("JCEKS");
+      keystore.load(pfxInputStream, KEYSTORE_PASSWORD.toCharArray());
+      return keystore;
+    } catch (FileNotFoundException fnfe) {
+      throw new ConnectorSecurityException(
+          "PFX file not found for keystore: " + KEYSTORE_PATH, fnfe);
+    } catch (KeyStoreException kse) {
+      throw new ConnectorSecurityException("Unexpected error initializing JCEKS instance", kse);
+    } catch (CertificateException | NoSuchAlgorithmException | IOException ee) {
+      throw new ConnectorSecurityException("Error while loading JCEKS keystore", ee);
+    }
+  }
+}

--- a/src/main/java/com/exclamationlabs/connid/base/connector/configuration/basetypes/security/KeyStoreConfiguration.java
+++ b/src/main/java/com/exclamationlabs/connid/base/connector/configuration/basetypes/security/KeyStoreConfiguration.java
@@ -39,4 +39,8 @@ public interface KeyStoreConfiguration extends ConnectorConfiguration {
   String getKeyAlias();
 
   void setKeyAlias(String keyAlias);
+
+  String getTlsVersion();
+
+  void setTlsVersion(String tlsVersion);
 }

--- a/src/main/java/com/exclamationlabs/connid/base/connector/configuration/basetypes/security/KeyStoreConfiguration.java
+++ b/src/main/java/com/exclamationlabs/connid/base/connector/configuration/basetypes/security/KeyStoreConfiguration.java
@@ -20,17 +20,17 @@ import com.exclamationlabs.connid.base.connector.configuration.ConnectorConfigur
 import org.identityconnectors.common.security.GuardedString;
 
 /**
- * Configuration properties for connectors that need to provide a PFX file as part of their
- * credentials for authentication.
+ * Configuration properties for connectors that need to provide a Keystore (generic) file as part of
+ * their credentials for authentication.
  */
-public interface PfxConfiguration extends ConnectorConfiguration {
-  String getPfxFile();
+public interface KeyStoreConfiguration extends ConnectorConfiguration {
+  String getKeystoreFile();
 
-  void setPfxFile(String input);
+  void setKeystoreFile(String input);
 
-  GuardedString getPfxPassword();
+  GuardedString getKeystorePassword();
 
-  void setPfxPassword(GuardedString input);
+  void setKeystorePassword(GuardedString input);
 
   GuardedString getKeyPassword();
 

--- a/src/main/java/com/exclamationlabs/connid/base/connector/configuration/basetypes/security/PfxConfiguration.java
+++ b/src/main/java/com/exclamationlabs/connid/base/connector/configuration/basetypes/security/PfxConfiguration.java
@@ -39,4 +39,8 @@ public interface PfxConfiguration extends ConnectorConfiguration {
   String getKeyAlias();
 
   void setKeyAlias(String keyAlias);
+
+  String getTlsVersion();
+
+  void setTlsVersion(String tlsVersion);
 }


### PR DESCRIPTION
Supports loading java keystores for loading cert/key pairs to secure communication with 3rd party APIs requiring mTLS certs